### PR TITLE
Properly close a tag to avoid errors with some ruby versions

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -8,7 +8,7 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  <%-# Spring executes the reloaders when files change. %>
+  <%-# Spring executes the reloaders when files change. -%>
   <%- if spring_install? -%>
   config.cache_classes = false
   config.action_view.cache_template_loading = true


### PR DESCRIPTION
This commit fixes  #38639

Properly closing a tag that raises an error if ruby version is 2.5.0



